### PR TITLE
fix saving meshes of real time demo

### DIFF
--- a/config/demo.yaml
+++ b/config/demo.yaml
@@ -1,6 +1,6 @@
 DATASET: 'demo'
 BATCH_SIZE: 1
-SAVE_SCENE_MESH: True  # only saves the first fragment when VIS_INCREMENTAL is turned on, will be fixed in the future.
+SAVE_SCENE_MESH: True
 SAVE_INCREMENTAL: False
 VIS_INCREMENTAL: False
 REDUCE_GPU_MEM: True  # Drastically reduces GPU memory and will slow down inference a bit.

--- a/datasets/demo.py
+++ b/datasets/demo.py
@@ -26,12 +26,6 @@ class DemoDataset(Dataset):
         with open(os.path.join(self.datapath, 'fragments.pkl'), 'rb') as f:
             metas = pickle.load(f)
 
-        if self.mode == 'test' and len(metas) != 0:
-            # make sure to save results for all scenes (utils.py:SaveScene)
-            extra = copy.deepcopy(metas[0])
-            extra['scene'] = 'ignore'
-            metas.append(extra)
-
         return metas
 
     def __len__(self):

--- a/demo.py
+++ b/demo.py
@@ -79,9 +79,7 @@ with torch.no_grad():
         # prepare for stuff
         scene = sample['scene'][0]
         save_mesh_scene.keyframe_id = frag_idx
-        # last fragment name is 'ignore' in datasets/demo.py
-        if scene != 'ignore':
-            save_mesh_scene.scene_name = scene.replace('/', '-')
+        save_mesh_scene.scene_name = scene.replace('/', '-')
 
         if cfg.SAVE_INCREMENTAL:
             save_mesh_scene.save_incremental(epoch_idx, 0, sample['imgs'][0], outputs)

--- a/utils.py
+++ b/utils.py
@@ -216,11 +216,6 @@ class SaveScene(object):
         #     self.tsdf_volume.append(torch.ones(dim).cuda())
         #     self.weight_volume.append(torch.zeros(dim).cuda())
 
-    def rotate_view(self):
-        ctr = self.vis.get_view_control()
-        ctr.rotate(10.0, 0.0)
-        return False
-
     @staticmethod
     def tsdf2mesh(voxel_size, origin, tsdf_vol):
         verts, faces, norms, vals = measure.marching_cubes(tsdf_vol, level=0)


### PR DESCRIPTION
Remove "ignore" in data loader,  fix the problem of saving the first instead of the last fragment in real time demo